### PR TITLE
⬆ Upgrade to lxml 4.9.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ attrs==22.1.0
     # via ebdtable2graph
 ebdtable2graph==0.0.2
     # via -r requirements.in
-lxml==4.9.1 # switch to version 4.9.0 (for windows + Python 3.11)
+lxml==4.9.2
     # via python-docx
 networkx==2.8.8
     # via ebdtable2graph


### PR DESCRIPTION
Should fix various Python 3.11 related problems on Windows