### PR TITLE
🥅 Catch errors in test explitly (instead of pokemon style)

### DIFF
--- a/unittests/test_highlevel.py
+++ b/unittests/test_highlevel.py
@@ -166,5 +166,5 @@ class TestEbdDocx2Table:
                             issue_number = "22"
                         case _:
                             raise
-                    error_msg = f"Error while scraping '{ebd_key}' (#{issue_number}): {value_error}"
+                    error_msg = f"Error while scraping '{ebd_key}' (#{issue_number})"
                     pytest.skip(error_msg)


### PR DESCRIPTION
this doesn't fix any thing but ensures that we get rid of error once and for all